### PR TITLE
Feat: Add WebSocket events for profile creation and iOS MPC integration

### DIFF
--- a/docs/MPC_IOS_INTEGRATION.md
+++ b/docs/MPC_IOS_INTEGRATION.md
@@ -1,0 +1,201 @@
+# MPC Wallet Generation - iOS Integration Guide
+
+## Overview
+
+This document explains how iOS should integrate with the backend for MPC wallet generation using Silence Labs SDK.
+
+## Architecture
+
+- **iOS App**: Holds P1 (Party 1) key share using Silence Labs SDK
+- **Duo-Node (Sigpair)**: Holds P2 (Party 2) key share
+- **Backend**: Manages profile creation and MPC wallet mapping
+- **MPC Structure**: 2-2 threshold signature scheme
+
+## Flow Diagram
+
+```
+iOS App                    Backend                     Duo-Node
+   |                          |                           |
+   |------ Create Profile --->|                           |
+   |<----- Profile Response --|                           |
+   |     (needsMpcGeneration) |                           |
+   |                          |                           |
+   |--- /mpc/generate ------->|                           |
+   |<-- Cloud Public Key -----|                           |
+   |                          |                           |
+   |------------ WebSocket Connection ------------------->|
+   |<----------- MPC Protocol Exchange ------------------>|
+   |                          |                           |
+   |-- /mpc/key-generated --->|                           |
+   |    (address, keyId)      |                           |
+   |<---- Success ------------|                           |
+```
+
+## Implementation Steps for iOS
+
+### 1. Profile Creation Response
+
+When creating a profile, check the response for MPC requirements:
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": "profile123",
+    "name": "My Profile",
+    "sessionWalletAddress": "0x...", // Placeholder address
+    "isDevelopmentWallet": false,
+    "needsMpcGeneration": true,  // NEW: Indicates MPC is needed
+    "createdAt": "2024-01-01T00:00:00Z"
+  }
+}
+```
+
+### 2. WebSocket Events
+
+Join the account room to receive real-time events:
+
+```swift
+// After login, join account room
+socket.emit("join_account", accountId)
+
+// Listen for profile creation events
+socket.on("profile_created") { data in
+    let profileData = data["data"] as? [String: Any]
+    let needsMpc = profileData["needsMpcGeneration"] as? Bool ?? false
+    
+    if needsMpc {
+        // Trigger MPC generation flow
+        startMpcGeneration(profile: profileData["profile"])
+    }
+}
+```
+
+### 3. MPC Generation Flow
+
+```swift
+func startMpcGeneration(profile: Profile) {
+    // Step 1: Get cloud public key from backend
+    let response = await api.post("/api/v2/mpc/generate", body: [
+        "profileId": profile.id
+    ])
+    
+    let cloudPublicKey = response.data.cloudPublicKey
+    let duoNodeUrl = response.data.duoNodeUrl
+    
+    // Step 2: Initialize Silence Labs SDK
+    let mpcClient = SilenceLabsSDK.initialize(
+        cloudPublicKey: cloudPublicKey,
+        party: .P1
+    )
+    
+    // Step 3: Connect to duo-node WebSocket
+    let duoSocket = WebSocket(url: duoNodeUrl)
+    duoSocket.connect()
+    
+    // Step 4: Perform MPC key generation
+    let keyGenResult = await mpcClient.generateKey(
+        socket: duoSocket,
+        profileId: profile.id
+    )
+    
+    // Step 5: Notify backend of completion
+    await api.post("/api/v2/mpc/key-generated", body: [
+        "profileId": profile.id,
+        "keyId": keyGenResult.keyId,
+        "publicKey": keyGenResult.publicKey,
+        "address": keyGenResult.address
+    ])
+}
+```
+
+### 4. Checking MPC Status
+
+To check if a profile has an MPC wallet:
+
+```swift
+// Check the needsMpcGeneration flag
+if profile.needsMpcGeneration {
+    // Profile needs MPC wallet generation
+    startMpcGeneration(profile: profile)
+}
+
+// Or check MPC status endpoint
+let status = await api.get("/api/v2/mpc/\(profileId)/status")
+if !status.data.hasKey {
+    // Profile needs MPC wallet generation
+}
+```
+
+## API Endpoints
+
+### Generate MPC Key
+```
+POST /api/v2/mpc/generate
+Body: {
+  "profileId": "string"
+}
+Response: {
+  "success": true,
+  "data": {
+    "profileId": "string",
+    "cloudPublicKey": "string",
+    "algorithm": "ecdsa|eddsa",
+    "duoNodeUrl": "string"
+  }
+}
+```
+
+### Key Generation Complete
+```
+POST /api/v2/mpc/key-generated
+Body: {
+  "profileId": "string",
+  "keyId": "string",
+  "publicKey": "string",
+  "address": "string"
+}
+Response: {
+  "success": true,
+  "data": {
+    "profile": { ... }
+  }
+}
+```
+
+### Check MPC Status
+```
+GET /api/v2/mpc/:profileId/status
+Response: {
+  "success": true,
+  "data": {
+    "profileId": "string",
+    "hasKey": boolean,
+    "keyAlgorithm": "ecdsa|eddsa",
+    "publicKey": "string",
+    "createdAt": "string"
+  }
+}
+```
+
+## Best Practices
+
+1. **Automatic Trigger**: Check `needsMpcGeneration` flag after profile creation
+2. **WebSocket Events**: Listen for `profile_created` events for real-time updates
+3. **Error Handling**: Implement retry logic for MPC generation failures
+4. **User Experience**: Show progress during MPC generation (it can take 10-30 seconds)
+5. **Security**: Never expose or log the P1 key share
+
+## Error Scenarios
+
+1. **MPC Generation Timeout**: Retry with exponential backoff
+2. **Network Issues**: Store pending MPC generation and retry on reconnection
+3. **Duplicate Key**: Check if profile already has MPC wallet before generating
+
+## Testing
+
+1. Create a profile with `developmentMode: false`
+2. Verify `needsMpcGeneration: true` in response
+3. Complete MPC generation flow
+4. Verify profile has real MPC address (not placeholder)
+5. Verify `needsMpcGeneration: false` on subsequent fetches

--- a/src/index.ts
+++ b/src/index.ts
@@ -509,6 +509,23 @@ Canonical: https://interspace.wallet/.well-known/security.txt
     this.io.on('connection', (socket) => {
       console.log('✅ Client connected:', socket.id);
 
+      // Account room management (for account-level events like profile creation)
+      socket.on('join_account', (accountId: string) => {
+        socket.join(`account:${accountId}`);
+        console.log(`📱 Client ${socket.id} joined account room: ${accountId}`);
+        
+        // Emit confirmation
+        socket.emit('account_joined', { accountId, timestamp: new Date().toISOString() });
+      });
+
+      socket.on('leave_account', (accountId: string) => {
+        socket.leave(`account:${accountId}`);
+        console.log(`📱 Client ${socket.id} left account room: ${accountId}`);
+        
+        // Emit confirmation
+        socket.emit('account_left', { accountId, timestamp: new Date().toISOString() });
+      });
+
       // Profile room management
       socket.on('join_profile', (profileId: string) => {
         socket.join(`profile:${profileId}`);
@@ -538,6 +555,10 @@ Canonical: https://interspace.wallet/.well-known/security.txt
 
     // Global broadcast method for service layer
     this.app.set('io', this.io);
+    
+    // Initialize websocket service
+    const { websocketService } = require('./services/websocketService');
+    websocketService.initialize(this.app);
   }
 
   private initializeErrorHandling(): void {

--- a/src/services/websocketService.ts
+++ b/src/services/websocketService.ts
@@ -181,6 +181,24 @@ export class WebSocketService {
       timestamp: new Date().toISOString()
     });
   }
+
+  /**
+   * Emit profile created event
+   */
+  emitProfileCreated(accountId: string, profile: any, needsMpcGeneration: boolean) {
+    if (!this.io) return;
+    
+    // Emit to the account's room (iOS client should join account room on login)
+    this.io.to(`account:${accountId}`).emit('profile_created', {
+      type: 'profile_created',
+      accountId,
+      data: {
+        profile,
+        needsMpcGeneration
+      },
+      timestamp: new Date().toISOString()
+    });
+  }
 }
 
 export const websocketService = new WebSocketService();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -90,6 +90,7 @@ export interface SmartProfileResponse {
   foldersCount: number;
   developmentMode?: boolean; // Indicates if this profile uses a development wallet
   isDevelopmentWallet?: boolean; // For iOS compatibility (same as developmentMode)
+  needsMpcGeneration?: boolean; // Indicates if MPC wallet generation is pending
   clientShare?: any; // Returned only for development wallets
   createdAt: string;
   updatedAt: string;

--- a/src/utils/tokenUtils.d.ts
+++ b/src/utils/tokenUtils.d.ts
@@ -1,0 +1,33 @@
+export interface TokenPayload {
+  accountId: string;
+  sessionToken: string;
+  deviceId?: string;
+  activeProfileId?: string;
+}
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+}
+
+export interface DecodedToken {
+  type: 'access' | 'refresh';
+  iat: number;
+  version: string;
+  accountId: string;
+  sessionToken: string;
+  deviceId?: string;
+  activeProfileId?: string;
+  userId?: string; // For backwards compatibility
+  exp?: number;
+  iss?: string;
+  aud?: string;
+  jti?: string;
+}
+
+export function generateTokens(payload: TokenPayload): AuthTokens;
+export function verifyRefreshToken(token: string): DecodedToken;
+export function verifyAccessToken(token: string): DecodedToken;
+export function extractTokenFromHeader(authHeader: string | undefined): string | null;
+export function isTokenExpired(token: string): boolean;


### PR DESCRIPTION
## Summary
- Adds WebSocket infrastructure for profile creation events to support iOS MPC key generation
- Updates profile controller to fully embrace flat identity model
- Includes TypeScript declarations and documentation

## Changes Made

### 1. **WebSocket Service Enhancement**
- Added `emitProfileCreated` method to notify clients when profiles are created
- Includes `needsMpcGeneration` flag to tell iOS when to generate MPC keys
- Properly initializes websocketService in application startup

### 2. **Account Room Management**
- Added `join_account` and `leave_account` WebSocket events
- Allows clients to subscribe to account-level events (like profile creation)
- Essential for iOS to know when to trigger MPC generation flow

### 3. **Profile Controller Updates**
- Removed legacy user table creation logic
- Now uses flat identity model exclusively with `accountId`
- Added `clientShare` parameter support for development profiles

### 4. **Smart Profile Service Integration**
- Updated to emit WebSocket events on profile creation
- Changed `formatProfileResponse` to async to support future enhancements
- Integrated websocketService throughout profile operations

### 5. **Additional Files**
- Added TypeScript declarations for tokenUtils
- Added MPC iOS integration documentation
- Updated type exports

## Use Case
When an iOS user creates a new profile:
1. Backend creates the profile and determines if MPC is needed
2. WebSocket emits `profile_created` event to the account room
3. iOS app receives the event with `needsMpcGeneration: true`
4. iOS app initiates MPC key generation with Silence Labs
5. iOS app completes the profile setup

## Test Plan
- [ ] WebSocket connection and room management works
- [ ] Profile creation emits proper WebSocket events
- [ ] iOS app receives profile_created events
- [ ] MPC generation flag is properly set
- [ ] Account room subscriptions work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)