### PR TITLE
feat: add WalletConnect One-Click Auth support

### DIFF
--- a/prisma/migrations/20250710_add_pending_auth_and_drift_fixes/migration.sql
+++ b/prisma/migrations/20250710_add_pending_auth_and_drift_fixes/migration.sql
@@ -1,0 +1,122 @@
+-- CreateTable PendingAuth (if not exists)
+CREATE TABLE IF NOT EXISTS "pending_auths" (
+    "id" TEXT NOT NULL,
+    "nonce" TEXT NOT NULL,
+    "address" TEXT NOT NULL,
+    "callbackUrl" TEXT,
+    "deviceId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "pending_auths_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable EmailVerification (if not exists)
+CREATE TABLE IF NOT EXISTS "email_verifications" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastAttemptAt" TIMESTAMP(3),
+
+    CONSTRAINT "email_verifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable FarcasterAuthChannel (if not exists)
+CREATE TABLE IF NOT EXISTS "farcaster_auth_channels" (
+    "id" TEXT NOT NULL,
+    "channelToken" TEXT NOT NULL,
+    "nonce" TEXT NOT NULL,
+    "domain" TEXT NOT NULL,
+    "siweUri" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "message" TEXT,
+    "signature" TEXT,
+    "fid" TEXT,
+    "username" TEXT,
+    "displayName" TEXT,
+    "bio" TEXT,
+    "pfpUrl" TEXT,
+    "custody" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "completedAt" TIMESTAMP(3),
+
+    CONSTRAINT "farcaster_auth_channels_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable AccountDelegation (if not exists)
+CREATE TABLE IF NOT EXISTS "account_delegations" (
+    "id" TEXT NOT NULL,
+    "linkedAccountId" TEXT NOT NULL,
+    "sessionWallet" TEXT NOT NULL,
+    "chainId" INTEGER NOT NULL,
+    "delegationType" TEXT NOT NULL DEFAULT 'eip7702',
+    "authorizationData" JSONB NOT NULL,
+    "permissions" JSONB NOT NULL,
+    "nonce" BIGINT NOT NULL,
+    "expiresAt" TIMESTAMP(3),
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "account_delegations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable BatchOperation (if not exists)
+CREATE TABLE IF NOT EXISTS "batch_operations" (
+    "id" TEXT NOT NULL,
+    "profileId" TEXT NOT NULL,
+    "batchId" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "operations" JSONB NOT NULL,
+    "results" JSONB,
+    "atomicExecution" BOOLEAN NOT NULL DEFAULT true,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "completedAt" TIMESTAMP(3),
+
+    CONSTRAINT "batch_operations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex for PendingAuth
+CREATE UNIQUE INDEX IF NOT EXISTS "pending_auths_nonce_key" ON "pending_auths"("nonce");
+CREATE INDEX IF NOT EXISTS "pending_auths_expiresAt_idx" ON "pending_auths"("expiresAt");
+CREATE INDEX IF NOT EXISTS "pending_auths_address_idx" ON "pending_auths"("address");
+
+-- CreateIndex for EmailVerification
+CREATE INDEX IF NOT EXISTS "email_verifications_email_code_idx" ON "email_verifications"("email", "code");
+CREATE INDEX IF NOT EXISTS "email_verifications_expiresAt_idx" ON "email_verifications"("expiresAt");
+
+-- CreateIndex for FarcasterAuthChannel
+CREATE UNIQUE INDEX IF NOT EXISTS "farcaster_auth_channels_channelToken_key" ON "farcaster_auth_channels"("channelToken");
+CREATE INDEX IF NOT EXISTS "farcaster_auth_channels_expiresAt_idx" ON "farcaster_auth_channels"("expiresAt");
+CREATE INDEX IF NOT EXISTS "farcaster_auth_channels_status_idx" ON "farcaster_auth_channels"("status");
+
+-- CreateIndex for AccountDelegation
+CREATE INDEX IF NOT EXISTS "account_delegations_linkedAccountId_sessionWallet_chainId_idx" ON "account_delegations"("linkedAccountId", "sessionWallet", "chainId");
+CREATE INDEX IF NOT EXISTS "account_delegations_isActive_expiresAt_idx" ON "account_delegations"("isActive", "expiresAt");
+
+-- CreateIndex for BatchOperation
+CREATE UNIQUE INDEX IF NOT EXISTS "batch_operations_batchId_key" ON "batch_operations"("batchId");
+CREATE INDEX IF NOT EXISTS "batch_operations_profileId_status_idx" ON "batch_operations"("profileId", "status");
+CREATE INDEX IF NOT EXISTS "batch_operations_batchId_idx" ON "batch_operations"("batchId");
+
+-- AddForeignKey (if not exists)
+DO $$ 
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'account_delegations_linkedAccountId_fkey') THEN
+        ALTER TABLE "account_delegations" ADD CONSTRAINT "account_delegations_linkedAccountId_fkey" FOREIGN KEY ("linkedAccountId") REFERENCES "linked_accounts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+DO $$ 
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'batch_operations_profileId_fkey') THEN
+        ALTER TABLE "batch_operations" ADD CONSTRAINT "batch_operations_profileId_fkey" FOREIGN KEY ("profileId") REFERENCES "smart_profiles"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;

--- a/src/middleware/authMiddlewareV2.js
+++ b/src/middleware/authMiddlewareV2.js
@@ -23,7 +23,9 @@ const authenticateAccount = async (req, res, next) => {
       originalUrl: req.originalUrl,
       baseUrl: req.baseUrl,
       method: req.method,
-      hasAuthHeader: !!req.headers.authorization
+      hasAuthHeader: !!req.headers.authorization,
+      fullPath: req.originalUrl || req.path,
+      pathWithoutQuery: (req.originalUrl || req.path).split('?')[0]
     });
     
     // Skip authentication for public endpoints

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -444,6 +444,89 @@ export class RateLimitError extends AppError {
   }
 }
 
+// App Store Types
+export interface AppStoreCategoryResponse {
+  id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  icon?: string;
+  position: number;
+  appsCount?: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AppStoreAppResponse {
+  id: string;
+  name: string;
+  url: string;
+  iconUrl?: string;
+  category: AppStoreCategoryResponse;
+  description: string;
+  detailedDescription?: string;
+  tags: string[];
+  popularity: number;
+  isNew: boolean;
+  isFeatured: boolean;
+  chainSupport: string[];
+  screenshots: string[];
+  developer?: string;
+  version?: string;
+  lastUpdated: string;
+  shareableId?: string;
+  metadata?: {
+    rating?: number;
+    reviewsCount?: number;
+    installsCount?: number;
+  };
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AppStoreSearchParams {
+  q?: string;
+  category?: string;
+  tags?: string[];
+  chains?: string[];
+  sortBy?: 'popularity' | 'newest' | 'name';
+  page?: number;
+  limit?: number;
+}
+
+export interface CreateAppStoreAppRequest {
+  name: string;
+  url: string;
+  iconUrl?: string;
+  categoryId: string;
+  description: string;
+  detailedDescription?: string;
+  tags?: string[];
+  chainSupport?: string[];
+  screenshots?: string[];
+  developer?: string;
+  version?: string;
+  isFeatured?: boolean;
+  isNew?: boolean;
+}
+
+export interface UpdateAppStoreAppRequest extends Partial<CreateAppStoreAppRequest> {
+  popularity?: number;
+  isActive?: boolean;
+}
+
+export interface CreateAppStoreCategoryRequest {
+  name: string;
+  slug: string;
+  description?: string;
+  icon?: string;
+  position?: number;
+}
+
+export interface UpdateAppStoreCategoryRequest extends Partial<CreateAppStoreCategoryRequest> {
+  isActive?: boolean;
+}
+
 // Utility Types
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type DeepPartial<T> = {

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -26,3 +26,8 @@ export function decrypt(payload: string): string {
   const decrypted = Buffer.concat([decipher.update(data), decipher.final()]);
   return decrypted.toString('utf8');
 }
+
+export function generateShareableId(): string {
+  // Generate a URL-safe random ID for shareable links
+  return crypto.randomBytes(16).toString('base64url');
+}


### PR DESCRIPTION
## Summary
- Implements WalletConnect One-Click Auth protocol for seamless mobile wallet authentication
- Adds support for callback URLs to enable deeplink flows back to mobile apps
- Extends SIWE service with AppKit-compliant message creation

## Changes
- Added `createWalletConnectMessage` method to SIWE service
- Created `PendingAuth` model for tracking mobile auth sessions
- Extended message expiration times for mobile flows (30 minutes)
- Added ReCaps resource support for permissions
- Updated auth routes to handle WalletConnect-specific parameters

## Test plan
- [ ] Test WalletConnect authentication flow from mobile app
- [ ] Verify callback URL handling and deeplink redirection
- [ ] Ensure backward compatibility with existing SIWE flows
- [ ] Test message expiration and cleanup

🤖 Generated with [Claude Code](https://claude.ai/code)