### PR TITLE
fix: Remove userId references from flat identity model

### DIFF
--- a/src/controllers/authControllerV2.js
+++ b/src/controllers/authControllerV2.js
@@ -1570,7 +1570,7 @@ const switchProfile = async (req, res, next) => {
     logger.info(`Profile switch requested for session ${req.sessionToken} to profile ${profileId}`);
 
     // Update profile active status
-    await smartProfileService.switchActiveProfile(profileId, targetProfile.userId);
+    await smartProfileService.switchActiveProfile(profileId, accountId);
 
     res.json({
       success: true,

--- a/src/controllers/profileControllerV2.js
+++ b/src/controllers/profileControllerV2.js
@@ -166,8 +166,7 @@ class ProfileControllerV2 {
       }
 
       // Update profile
-      const userId = profile.userId || req.user?.userId;
-      const updatedProfile = await smartProfileService.updateProfile(profileId, userId, { name });
+      const updatedProfile = await smartProfileService.updateProfile(profileId, accountId, { name });
 
       res.json({
         success: true,
@@ -215,8 +214,7 @@ class ProfileControllerV2 {
       // Even if it's the last one
 
       // Delete profile
-      const userId = profile.userId || req.user?.userId;
-      await smartProfileService.deleteProfile(profileId, userId);
+      await smartProfileService.deleteProfile(profileId, accountId);
 
       res.json({
         success: true,
@@ -255,8 +253,7 @@ class ProfileControllerV2 {
       }
 
       // Rotate wallet
-      const userId = profile.userId || req.user?.userId;
-      const updatedProfile = await smartProfileService.rotateSessionWallet(profileId, userId);
+      const updatedProfile = await smartProfileService.rotateSessionWallet(profileId, accountId);
 
       res.json({
         success: true,
@@ -314,7 +311,6 @@ class ProfileControllerV2 {
       // Return the actual LinkedAccount records with their correct IDs
       const formattedAccounts = linkedAccounts.map(account => ({
         id: account.id, // This is the LinkedAccount ID
-        userId: account.userId,
         profileId: account.profileId,
         address: account.address,
         authStrategy: account.authStrategy,
@@ -426,7 +422,6 @@ class ProfileControllerV2 {
       // Create the linked account
       const linkedAccount = await prisma.linkedAccount.create({
         data: {
-          userId: profile.userId,
           profileId: profileId,
           address: address.toLowerCase(),
           authStrategy: 'wallet',
@@ -469,7 +464,6 @@ class ProfileControllerV2 {
         success: true,
         data: {
           id: linkedAccount.id,
-          userId: linkedAccount.userId,
           profileId: linkedAccount.profileId,
           address: linkedAccount.address,
           authStrategy: linkedAccount.authStrategy,


### PR DESCRIPTION
## Summary
- Remove all userId references that were causing "Null constraint violation" errors in production
- Update controllers to use accountId from the flat identity model

## Problem
The production deployment is failing with:
```
Null constraint violation on the fields: (`userId`)
```

This occurs because:
1. The database was migrated to remove userId fields (migration `20250702_remove_user_and_userid_columns`)
2. The deployed code still contained references to these removed fields
3. When creating profiles or linked accounts, the code tried to insert userId which no longer exists in the schema

## Changes
- **profileControllerV2.js**: 
  - Removed `userId` from LinkedAccount creation
  - Removed `userId` from response objects
  - Updated service method calls to use `accountId` instead of `userId`
- **authControllerV2.js**: 
  - Fixed `switchProfile` to use `accountId` instead of `targetProfile.userId`

## Test plan
- [x] Build passes locally
- [x] Prisma client regenerated
- [ ] Test profile creation endpoint
- [ ] Test profile switching endpoint
- [ ] Test linking accounts to profiles

🤖 Generated with [Claude Code](https://claude.ai/code)