### PR TITLE
Remove userId references from flat identity model

### DIFF
--- a/src/controllers/profileControllerV2.js
+++ b/src/controllers/profileControllerV2.js
@@ -2,6 +2,7 @@ const { validationResult } = require('express-validator');
 const { logger } = require('../utils/logger');
 const { smartProfileService } = require('../services/smartProfileService');
 const accountService = require('../services/accountService');
+const { prisma, withRetryableTransaction } = require('../utils/database');
 
 /**
  * V2 Profile Controller - Works with flat identity model
@@ -12,6 +13,7 @@ class ProfileControllerV2 {
    */
   async getProfiles(req, res, next) {
     try {
+      
       const accountId = req.account?.id || req.user?.accountId;  // Support both account and legacy user objects
       
       // Debug logging
@@ -30,8 +32,109 @@ class ProfileControllerV2 {
         });
       }
 
-      // Get all accessible profiles based on identity graph
-      const profiles = await accountService.getAccessibleProfiles(accountId);
+      // Get profiles via LinkedAccount (single source of truth)
+      const account = await prisma.account.findUnique({
+        where: { id: accountId }
+      });
+      
+      if (!account) {
+        return res.status(404).json({
+          success: false,
+          error: 'Account not found'
+        });
+      }
+      
+      const authStrategy = account.type === 'social' ? account.provider : account.type;
+      
+      logger.info('Fetching profiles for account', {
+        accountId: account.id,
+        accountType: account.type,
+        provider: account.provider,
+        identifier: account.identifier,
+        authStrategy: authStrategy
+      });
+      
+      let profiles = await accountService.getProfilesForLinkedAccount(account.identifier, authStrategy);
+      
+      // Debug: Log all LinkedAccount entries for this address
+      const allLinkedAccounts = await prisma.linkedAccount.findMany({
+        where: {
+          address: account.identifier.toLowerCase()
+        },
+        include: {
+          profile: true
+        }
+      });
+      
+      
+      logger.info('Debug: All LinkedAccount entries for this address', {
+        address: account.identifier.toLowerCase(),
+        count: allLinkedAccounts.length,
+        entries: allLinkedAccounts.map(la => ({
+          id: la.id,
+          profileId: la.profileId,
+          profileName: la.profile.name,
+          authStrategy: la.authStrategy,
+          isActive: la.isActive,
+          isPrimary: la.isPrimary
+        }))
+      });
+      
+      // Fallback: If no profiles found via LinkedAccount, check ProfileAccount for backward compatibility
+      if (profiles.length === 0) {
+        logger.info('No profiles found via LinkedAccount, checking ProfileAccount for backward compatibility', {
+          accountId,
+          identifier: account.identifier,
+          authStrategy
+        });
+        
+        const profileAccounts = await prisma.profileAccount.findMany({
+          where: { accountId },
+          include: {
+            profile: {
+              include: {
+                linkedAccounts: true,
+                folders: {
+                  include: {
+                    apps: true
+                  }
+                },
+                _count: {
+                  select: {
+                    linkedAccounts: true,
+                    apps: true,
+                    folders: true
+                  }
+                }
+              }
+            }
+          }
+        });
+        
+        // For each profile found, create a LinkedAccount entry
+        for (const pa of profileAccounts) {
+          try {
+            await prisma.linkedAccount.create({
+              data: {
+                profileId: pa.profile.id,
+                address: account.identifier.toLowerCase(),
+                authStrategy: authStrategy,
+                walletType: account.type === 'wallet' ? (account.metadata?.walletType || 'external') : null,
+                isPrimary: pa.isPrimary,
+                isActive: true,
+                chainId: account.metadata?.chainId ? parseInt(account.metadata.chainId) : 1,
+                metadata: JSON.stringify(account.metadata || {})
+              }
+            });
+            logger.info(`Created LinkedAccount for backward compatibility: profile ${pa.profile.id}, account ${accountId}`);
+          } catch (error) {
+            // Might already exist, ignore
+            logger.warn(`Could not create LinkedAccount (may already exist):`, error.message);
+          }
+        }
+        
+        profiles = profileAccounts.map(pa => pa.profile);
+      }
       
       res.json({
         success: true,
@@ -107,14 +210,52 @@ class ProfileControllerV2 {
         });
       }
 
-      // Check if account has access to this profile
-      const profiles = await accountService.getAccessibleProfiles(accountId);
-      const profile = profiles.find(p => p.id === profileId);
+      // Check if account has access to this profile via LinkedAccount
+      const account = await prisma.account.findUnique({
+        where: { id: accountId }
+      });
+      
+      if (!account) {
+        return res.status(404).json({
+          success: false,
+          error: 'Account not found'
+        });
+      }
+      
+      const hasAccess = await prisma.linkedAccount.findFirst({
+        where: {
+          profileId: profileId,
+          address: account.identifier.toLowerCase(),
+          isActive: true
+        }
+      });
 
-      if (!profile) {
+      if (!hasAccess) {
         return res.status(404).json({
           success: false,
           error: 'Profile not found or not accessible'
+        });
+      }
+
+      // Fetch the actual profile data
+      const profile = await prisma.smartProfile.findUnique({
+        where: { id: profileId },
+        include: {
+          linkedAccounts: true,
+          folders: true,
+          _count: {
+            select: {
+              apps: true,
+              folders: true
+            }
+          }
+        }
+      });
+
+      if (!profile || !profile.isActive) {
+        return res.status(404).json({
+          success: false,
+          error: 'Profile not found or inactive'
         });
       }
 
@@ -154,11 +295,27 @@ class ProfileControllerV2 {
         });
       }
 
-      // Check if account has access to this profile
-      const profiles = await accountService.getAccessibleProfiles(accountId);
-      const profile = profiles.find(p => p.id === profileId);
+      // Check if account has access to this profile via LinkedAccount
+      const account = await prisma.account.findUnique({
+        where: { id: accountId }
+      });
+      
+      if (!account) {
+        return res.status(404).json({
+          success: false,
+          error: 'Account not found'
+        });
+      }
+      
+      const hasAccess = await prisma.linkedAccount.findFirst({
+        where: {
+          profileId: profileId,
+          address: account.identifier.toLowerCase(),
+          isActive: true
+        }
+      });
 
-      if (!profile) {
+      if (!hasAccess) {
         return res.status(404).json({
           success: false,
           error: 'Profile not found or not accessible'
@@ -199,11 +356,27 @@ class ProfileControllerV2 {
         });
       }
 
-      // Check if account has access to this profile
-      const profiles = await accountService.getAccessibleProfiles(accountId);
-      const profile = profiles.find(p => p.id === profileId);
+      // Check if account has access to this profile via LinkedAccount
+      const account = await prisma.account.findUnique({
+        where: { id: accountId }
+      });
+      
+      if (!account) {
+        return res.status(404).json({
+          success: false,
+          error: 'Account not found'
+        });
+      }
+      
+      const hasAccess = await prisma.linkedAccount.findFirst({
+        where: {
+          profileId: profileId,
+          address: account.identifier.toLowerCase(),
+          isActive: true
+        }
+      });
 
-      if (!profile) {
+      if (!hasAccess) {
         return res.status(404).json({
           success: false,
           error: 'Profile not found or not accessible'
@@ -241,11 +414,27 @@ class ProfileControllerV2 {
         });
       }
 
-      // Check if account has access to this profile
-      const profiles = await accountService.getAccessibleProfiles(accountId);
-      const profile = profiles.find(p => p.id === profileId);
+      // Check if account has access to this profile via LinkedAccount
+      const account = await prisma.account.findUnique({
+        where: { id: accountId }
+      });
+      
+      if (!account) {
+        return res.status(404).json({
+          success: false,
+          error: 'Account not found'
+        });
+      }
+      
+      const hasAccess = await prisma.linkedAccount.findFirst({
+        where: {
+          profileId: profileId,
+          address: account.identifier.toLowerCase(),
+          isActive: true
+        }
+      });
 
-      if (!profile) {
+      if (!hasAccess) {
         return res.status(404).json({
           success: false,
           error: 'Profile not found or not accessible'
@@ -285,11 +474,27 @@ class ProfileControllerV2 {
         });
       }
 
-      // Check if account has access to this profile
-      const profiles = await accountService.getAccessibleProfiles(accountId);
-      const profile = profiles.find(p => p.id === profileId);
+      // Check if account has access to this profile via LinkedAccount
+      const account = await prisma.account.findUnique({
+        where: { id: accountId }
+      });
+      
+      if (!account) {
+        return res.status(404).json({
+          success: false,
+          error: 'Account not found'
+        });
+      }
+      
+      const hasAccess = await prisma.linkedAccount.findFirst({
+        where: {
+          profileId: profileId,
+          address: account.identifier.toLowerCase(),
+          isActive: true
+        }
+      });
 
-      if (!profile) {
+      if (!hasAccess) {
         return res.status(404).json({
           success: false,
           error: 'Profile not found or not accessible'
@@ -335,7 +540,7 @@ class ProfileControllerV2 {
   }
 
   /**
-   * Link a new account (wallet) to a profile
+   * Link a new account (wallet or email) to a profile
    */
   async linkAccountToProfile(req, res, next) {
     try {
@@ -348,7 +553,7 @@ class ProfileControllerV2 {
       }
 
       const { profileId } = req.params;
-      const { address, walletType, signature, message } = req.body;
+      const { address, walletType, signature, message, verificationCode } = req.body;
       const accountId = req.account?.id;
 
       logger.info('ProfileControllerV2.linkAccountToProfile - Request:', {
@@ -367,118 +572,307 @@ class ProfileControllerV2 {
         });
       }
 
-      // Check if the account has access to this profile
-      const hasAccess = await accountService.hasAccessToProfile(accountId, profileId);
-      if (!hasAccess) {
-        return res.status(403).json({
+      // Use linkedAccountService to handle all account types (wallet, email, etc.)
+      const { linkedAccountService } = require('../services/linkedAccountService');
+      
+      try {
+        const result = await linkedAccountService.linkAccount(
+          profileId,
+          accountId,
+          {
+            address,
+            walletType: walletType || 'unknown',
+            signature,
+            message,
+            verificationCode,
+            ipAddress: req.ip,
+            userAgent: req.headers['user-agent']
+          }
+        );
+
+        logger.info('ProfileControllerV2.linkAccountToProfile - Success:', {
+          profileId,
+          linkedAccountId: result.id,
+          address: result.address,
+          walletType: result.walletType
+        });
+
+        res.json({
+          success: true,
+          data: result
+        });
+      } catch (serviceError) {
+        // Handle specific service errors
+        if (serviceError.name === 'NotFoundError') {
+          return res.status(404).json({
+            success: false,
+            error: serviceError.message
+          });
+        } else if (serviceError.name === 'ConflictError') {
+          return res.status(409).json({
+            success: false,
+            error: serviceError.message
+          });
+        } else if (serviceError.name === 'AuthorizationError') {
+          return res.status(403).json({
+            success: false,
+            error: serviceError.message
+          });
+        }
+        
+        // Re-throw other errors to be handled by the global error handler
+        throw serviceError;
+      }
+    } catch (error) {
+      logger.error('Link account to profile error:', error);
+      next(error);
+    }
+  }
+
+  /**
+   * Unlink an account from a profile
+   */
+  async unlinkAccountFromProfile(req, res, next) {
+    try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return res.status(400).json({
           success: false,
-          error: 'Access denied to this profile'
+          errors: errors.array()
         });
       }
 
-      // Verify the wallet signature
-      const { siweService } = require('../services/siweService');
-      const verificationResult = await siweService.verifyMessage({
-        message,
-        signature
+      const { profileId, accountId: linkedAccountId } = req.params;
+      const accountId = req.account?.id;
+
+      logger.info('ProfileControllerV2.unlinkAccountFromProfile - Request:', {
+        profileId,
+        linkedAccountId,
+        accountId
       });
 
-      if (!verificationResult.valid || verificationResult.address.toLowerCase() !== address.toLowerCase()) {
+      if (!accountId) {
         return res.status(401).json({
           success: false,
-          error: 'Invalid wallet signature'
+          error: 'Authentication required'
         });
       }
 
-      // Check if this wallet is already linked to this specific profile
-      const { prisma } = require('../utils/database');
-      const existingLinkedAccount = await prisma.linkedAccount.findFirst({
+      // Use linkedAccountService to handle unlinking
+      const { linkedAccountService } = require('../services/linkedAccountService');
+      
+      try {
+        await linkedAccountService.unlinkAccount(linkedAccountId, accountId);
+
+        logger.info('ProfileControllerV2.unlinkAccountFromProfile - Success:', {
+          profileId,
+          linkedAccountId
+        });
+
+        res.json({
+          success: true,
+          message: 'Account unlinked successfully'
+        });
+      } catch (serviceError) {
+        // Handle specific service errors
+        if (serviceError.name === 'NotFoundError') {
+          return res.status(404).json({
+            success: false,
+            error: 'Account not found'
+          });
+        }
+        
+        if (serviceError.name === 'AuthorizationError') {
+          return res.status(403).json({
+            success: false,
+            error: serviceError.message || 'You do not have permission to unlink this account'
+          });
+        }
+        
+        // Let other errors bubble up to error handler
+        throw serviceError;
+      }
+
+    } catch (error) {
+      logger.error('Unlink account from profile error:', error);
+      next(error);
+    }
+  }
+
+  /**
+   * Update linked account metadata
+   */
+  async updateLinkedAccount(req, res, next) {
+    try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return res.status(400).json({
+          success: false,
+          errors: errors.array()
+        });
+      }
+
+      const { profileId, accountId: linkedAccountId } = req.params;
+      const { customName, isPrimary } = req.body;
+      const accountId = req.account?.id;
+
+      logger.info('ProfileControllerV2.updateLinkedAccount - Request:', {
+        profileId,
+        linkedAccountId,
+        accountId,
+        customName,
+        isPrimary
+      });
+
+      if (!accountId) {
+        return res.status(401).json({
+          success: false,
+          error: 'Authentication required'
+        });
+      }
+
+      // Use linkedAccountService to handle the update
+      const { linkedAccountService } = require('../services/linkedAccountService');
+      
+      try {
+        const updatedAccount = await linkedAccountService.updateLinkedAccount(
+          linkedAccountId,
+          accountId,
+          {
+            customName,
+            isPrimary
+          }
+        );
+
+        logger.info('ProfileControllerV2.updateLinkedAccount - Success:', {
+          profileId,
+          linkedAccountId,
+          updatedAccount
+        });
+
+        res.json({
+          success: true,
+          data: updatedAccount
+        });
+      } catch (serviceError) {
+        // Handle specific service errors
+        if (serviceError.name === 'NotFoundError') {
+          return res.status(404).json({
+            success: false,
+            error: 'Account not found'
+          });
+        }
+        
+        if (serviceError.name === 'AuthorizationError') {
+          return res.status(403).json({
+            success: false,
+            error: serviceError.message || 'You do not have permission to update this account'
+          });
+        }
+        
+        // Let other errors bubble up to error handler
+        throw serviceError;
+      }
+
+    } catch (error) {
+      logger.error('Update linked account error:', error);
+      next(error);
+    }
+  }
+
+  /**
+   * Delete a profile
+   */
+  async deleteProfile(req, res, next) {
+    try {
+      const { profileId } = req.params;
+      const accountId = req.account?.id || req.user?.accountId;
+      
+      if (!accountId) {
+        return res.status(401).json({
+          success: false,
+          error: 'Account ID required'
+        });
+      }
+      
+      // Verify account has access via LinkedAccount
+      const account = await prisma.account.findUnique({
+        where: { id: accountId }
+      });
+      
+      if (!account) {
+        return res.status(404).json({
+          success: false,
+          error: 'Account not found'
+        });
+      }
+      
+      const hasAccess = await prisma.linkedAccount.findFirst({
         where: {
-          address: address.toLowerCase(),
           profileId: profileId,
+          address: account.identifier.toLowerCase(),
           isActive: true
         }
       });
-
-      if (existingLinkedAccount) {
-        return res.status(409).json({
+      
+      if (!hasAccess) {
+        return res.status(403).json({
           success: false,
-          error: 'This wallet is already linked to this profile'
+          error: 'Not authorized to delete this profile'
         });
       }
-
-      // Get the profile to find the userId
-      const profile = await prisma.smartProfile.findUnique({
-        where: { id: profileId }
-      });
-
-      if (!profile) {
-        return res.status(404).json({
-          success: false,
-          error: 'Profile not found'
+      
+      // Check if this is the last profile for the user
+      const profiles = await accountService.getProfilesForLinkedAccount(account);
+      const isLastProfile = profiles.length <= 1;
+      
+      // Delete profile and all related data in transaction
+      await withRetryableTransaction(async (tx) => {
+        // Delete linked accounts
+        await tx.linkedAccount.deleteMany({
+          where: { profileId }
         });
+        
+        // Delete profile accounts
+        await tx.profileAccount.deleteMany({
+          where: { profileId }
+        });
+        
+        // Delete folders
+        await tx.folder.deleteMany({
+          where: { profileId }
+        });
+        
+        // Delete apps
+        await tx.app.deleteMany({
+          where: { profileId }
+        });
+        
+        // Delete the profile
+        await tx.smartProfile.delete({
+          where: { id: profileId }
+        });
+      });
+      
+      // If not the last profile, activate another profile
+      let newActiveProfile = null;
+      if (!isLastProfile) {
+        const remainingProfiles = await accountService.getProfilesForLinkedAccount(account);
+        if (remainingProfiles.length > 0) {
+          newActiveProfile = remainingProfiles[0];
+          await smartProfileService.activateProfile(newActiveProfile.id, accountId);
+        }
       }
-
-      // Create the linked account
-      const linkedAccount = await prisma.linkedAccount.create({
-        data: {
-          profileId: profileId,
-          address: address.toLowerCase(),
-          authStrategy: 'wallet',
-          walletType: walletType || 'unknown',
-          isPrimary: false, // New linked accounts are not primary by default
-          isActive: true,
-          metadata: JSON.stringify({
-            linkedAt: new Date().toISOString(),
-            linkedBy: accountId
-          })
-        }
-      });
-
-      // Also create/link the wallet account in the identity graph
-      const walletAccount = await accountService.findOrCreateAccount({
-        type: 'wallet',
-        identifier: address.toLowerCase(),
-        verified: true,
-        metadata: {
-          walletType: walletType || 'unknown'
-        }
-      });
-
-      // Link to the current account in the identity graph
-      await accountService.linkAccounts(
-        accountId,
-        walletAccount.id,
-        'direct',
-        'linked'
-      );
-
-      logger.info('ProfileControllerV2.linkAccountToProfile - Success:', {
-        profileId,
-        linkedAccountId: linkedAccount.id,
-        walletAccountId: walletAccount.id,
-        address: linkedAccount.address
-      });
-
+      
       res.json({
         success: true,
-        data: {
-          id: linkedAccount.id,
-          profileId: linkedAccount.profileId,
-          address: linkedAccount.address,
-          authStrategy: linkedAccount.authStrategy,
-          walletType: linkedAccount.walletType,
-          customName: linkedAccount.customName,
-          isPrimary: linkedAccount.isPrimary,
-          isActive: linkedAccount.isActive,
-          chainId: linkedAccount.chainId,
-          metadata: linkedAccount.metadata,
-          createdAt: linkedAccount.createdAt,
-          updatedAt: linkedAccount.updatedAt
-        }
+        isLastProfile,
+        activeProfile: newActiveProfile,
+        remainingProfiles: isLastProfile ? [] : await accountService.getProfilesForLinkedAccount(account)
       });
+      
     } catch (error) {
-      logger.error('Link account to profile error:', error);
+      logger.error('Delete profile error:', error);
       next(error);
     }
   }


### PR DESCRIPTION
## Summary
- Remove userId references from authentication and profile controllers to complete flat identity model transition
- Update middleware to work with account-based authentication only
- Clean up profile access verification to use account-based checks
- Simplify account service to focus on account entities
- Remove legacy userId handling from smart profile service
- Improve backward compatibility for ProfileAccount migration

## Changes Made
- **Authentication Controller**: Removed userId references, now uses accountId as primary identifier
- **Profile Controller**: Updated to work with account-based access control via LinkedAccount
- **Auth Middleware**: Simplified to authenticate accounts directly without user entity dependency
- **Account Service**: Focused on account-centric operations, removed user-related complexity
- **Smart Profile Service**: Removed userId parameters and legacy user handling
- **Profile Access Utility**: Updated access checks to use account-based verification

## Impact
- Completes the transition to flat identity model where accounts are the primary identity entity
- Removes complexity of managing separate user entities in most operations
- Maintains backward compatibility with existing ProfileAccount system
- Improves code consistency and reduces potential bugs from dual identity systems

## Test plan
- [ ] Verify authentication flow works with account-based tokens
- [ ] Test profile creation and access with account-based authentication
- [ ] Confirm backward compatibility with existing ProfileAccount entries
- [ ] Validate LinkedAccount system works correctly with account-based access
- [ ] Test edge cases for account verification and session management

🤖 Generated with [Claude Code](https://claude.ai/code)