### PR TITLE
feat: update local development configuration for Docker services

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -85,7 +85,7 @@ services:
       - CORS_ORIGINS=http://localhost:3000,http://localhost:19006,http://localhost:3001
       # Required MPC/Orby settings
       - SILENCE_ADMIN_TOKEN=local-test-token
-      - SILENCE_NODE_URL=https://sigpair-dev-784862970473.us-central1.run.app
+      - SILENCE_NODE_URL=http://sigpair:8080
       - DUO_NODE_URL=http://duo-node:3001
       - DUO_NODE_AUDIENCE_URL=http://duo-node:3001
       - ORBY_INSTANCE_PRIVATE_API_KEY=c669420b-1cca-4a62-ab6c-a580fd06d575

--- a/src/services/mpcKeyShareService.ts
+++ b/src/services/mpcKeyShareService.ts
@@ -109,7 +109,9 @@ class MpcKeyShareService {
     // For local development, fetch the verifying key from sigpair directly
     try {
       // In local development, sigpair runs on port 8080
-      const sigpairUrl = process.env.NODE_ENV === 'development' ? 'http://sigpair:8080' : (this.duoNodeUrl || 'http://duo-node:3001');
+      const sigpairUrl = process.env.NODE_ENV === 'development' 
+        ? (process.env.SILENCE_NODE_URL || 'http://sigpair:8080')
+        : (this.duoNodeUrl || 'http://duo-node:3001');
       
       // For local development, use axios directly without Google auth
       const isLocalDevelopment = process.env.NODE_ENV === 'development' || sigpairUrl.includes('localhost') || sigpairUrl.includes('sigpair');


### PR DESCRIPTION
## Summary
- Updates local development configuration to use Docker services instead of external dependencies
- Configures SILENCE_NODE_URL to point to local sigpair service
- Updates mpcKeyShareService to respect SILENCE_NODE_URL environment variable

## Changes
- `docker-compose.local.yml`: Changed SILENCE_NODE_URL from cloud URL to local Docker service
- `src/services/mpcKeyShareService.ts`: Updated to use SILENCE_NODE_URL env var in development mode

## Test plan
- [ ] Start local Docker environment with `docker-compose -f docker-compose.local.yml up`
- [ ] Verify sigpair service is accessible at http://sigpair:8080
- [ ] Test MPC key share functionality works with local services

🤖 Generated with [Claude Code](https://claude.ai/code)